### PR TITLE
Update korp links

### DIFF
--- a/data/resources/fao-korp.ts
+++ b/data/resources/fao-korp.ts
@@ -9,7 +9,7 @@ const l10nLanguages = getL10NLanguages(resourceLang)
 const halfLinks = [
   {
     type: LinkType.Normal,
-    url: new URL("https://gtweb.uit.no/f_korp/?mode=fao#?lang=en"),
+    url: new URL("https://gtweb.uit.no/korp/fao"),
   },
 ]
 

--- a/data/resources/fit-korp.ts
+++ b/data/resources/fit-korp.ts
@@ -9,7 +9,7 @@ const l10nLanguages = getL10NLanguages(resourceLang)
 const halfLinks = [
   {
     type: LinkType.Normal,
-    url: new URL("https://gtweb.uit.no/f_korp/?mode=fit#?lang=en"),
+    url: new URL("https://gtweb.uit.no/korp/fit"),
   },
 ]
 

--- a/data/resources/fkv-korp.ts
+++ b/data/resources/fkv-korp.ts
@@ -9,7 +9,7 @@ const l10nLanguages = getL10NLanguages(resourceLang)
 const halfLinks = [
   {
     type: LinkType.Normal,
-    url: new URL("https://gtweb.uit.no/f_korp/#?lang=en"),
+    url: new URL("https://gtweb.uit.no/korp/fao"),
   },
 ]
 const resource: Resource = {

--- a/data/resources/sma-korp.ts
+++ b/data/resources/sma-korp.ts
@@ -9,7 +9,7 @@ const l10nLanguages = getL10NLanguages(resourceLang)
 const halfLinks = [
   {
     type: LinkType.Normal,
-    url: new URL("https://gtweb.uit.no/korp/?mode=sma#?lang=en"),
+    url: new URL("https://gtweb.uit.no/korp/"),
   },
 ]
 

--- a/data/resources/sme-korp.ts
+++ b/data/resources/sme-korp.ts
@@ -9,7 +9,7 @@ const l10nLanguages = getL10NLanguages(resourceLang)
 const halfLinks = [
   {
     type: LinkType.Normal,
-    url: new URL("https://gtweb.uit.no/korp/#?lang=en"),
+    url: new URL("https://gtweb.uit.no/korp/"),
   },
 ]
 

--- a/data/resources/smj-korp.ts
+++ b/data/resources/smj-korp.ts
@@ -9,7 +9,7 @@ const l10nLanguages = getL10NLanguages(resourceLang)
 const halfLinks = [
   {
     type: LinkType.Normal,
-    url: new URL("https://gtweb.uit.no/korp/?mode=smj#?lang=en"),
+    url: new URL("https://gtweb.uit.no/korp/"),
   },
 ]
 

--- a/data/resources/sms-korp.ts
+++ b/data/resources/sms-korp.ts
@@ -9,7 +9,7 @@ const l10nLanguages = getL10NLanguages(resourceLang)
 const halfLinks = [
   {
     type: LinkType.Normal,
-    url: new URL("https://gtweb.uit.no/korp/?mode=sms#?lang=en"),
+    url: new URL("https://gtweb.uit.no/korp/sms"),
   },
 ]
 


### PR DESCRIPTION
For most, use the new direct link. However, parallel corpora still exist at old korp only, thus use the korp landing page for sme, sma, smj and smn.